### PR TITLE
Don't remove contents of /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV BITNAMI_APP_NAME=java-play \
 RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list && apt-get update && \
     apt-get install -y --no-install-recommends openjdk-8-jdk && \
     apt-get clean && \
-    rm -rf /var/lib/apt /var/cache/apt/archives/* /tmp/*
+    rm -rf /var/lib/apt /var/cache/apt/archives/*
 
 # Install Play dependencies
 RUN bitnami-pkg install node-6.6.0-1 --checksum 36f42bb71b35f95db3bb21d088fbd9438132fb2a7fb4d73b5951732db9a6771e


### PR DESCRIPTION
When updating the container images, we are copying packages into
`/tmp/bitnami/pkg/cache` but later we are removing the contents of
`/tmp` before installing the package. This change removes this step.